### PR TITLE
Adds msmpi support

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
 mpi:
   - openmpi
   - mpich
+  - msmpi

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
 mpi:
-  - openmpi
-  - mpich
-  - msmpi
+  - openmpi # [not win]
+  - mpich   # [not win]
+  - msmpi   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,6 @@ build:
   # manually we would not be producing unique filenames.
   number: 0
   string: {{ mpi }}
-  # TODO: support Windows when msmpi is packaged
-  skip: true  # [win]
 
 requirements: {}
   # None, mpi providers should depend on me

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,7 @@ about:
     `mpi-feedstock` is a metapackage that serves as a mutex to ensure only a single MPI variant is present. Available variants can be found
     in `./conda-build-config.yaml`. If a package needs to include an MPI variant, you can specify it in the pinnings. For example: `- mpi 1.0 mpich`.
   dev_url: https://github.com/AnacondaRecipes/mpi-feedstock
+  doc_url: https://github.com/AnacondaRecipes/mpi-feedstock/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,10 +24,15 @@ test:
     - echo "I'm a metapackage"
 
 about:
-  home: https://github.com/conda-forge/mpi-feedstock
-  license: BSD 3-clause
+  home: https://github.com/AnacondaRecipes/mpi-feedstock
+  license: BSD-3-Clause
+  license_family: BSD
   license_file: {{ RECIPE_DIR if RECIPE_DIR is defined else '' }}/LICENSE.txt
   summary: Metapackage to select the MPI variant. Use conda's pinning mechanism in your environment to control which variant you want.
+  description: |
+    `mpi-feedstock` is a metapackage that serves as a mutex to ensure only a single MPI variant is present. Available variants can be found
+    in `./conda-build-config.yaml`. If a package needs to include an MPI variant, you can specify it in the pinnings. For example: `- mpi 1.0 mpich`.
+  dev_url: https://github.com/AnacondaRecipes/mpi-feedstock
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# mpi-feedstock

This is a mutex package for MPI variants. This PR adds support for the [msmpi variant](https://github.com/AnacondaRecipes/msmpi-feedstock/pull/1)

## Changes
- Add msmpi to list of supported MPI variants
- Remove skipping win-64 now that there is a supported MPI variant for Windows
- Update about section 